### PR TITLE
Fix #18991 SqlServer incorrect date format

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -372,16 +372,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Get the format for database stored dates.
-     *
-     * @return string
-     */
-    public function getDateFormat()
-    {
-        return 'Y-m-d H:i:s.000';
-    }
-
-    /**
      * Wrap a single string in keyword identifiers.
      *
      * @param  string  $value


### PR DESCRIPTION
With the fix from https://bugs.php.net/bug.php?id=54648 the date format used by
SQL Server is hard coded into PHP. Luckily that matches the default format of
other systems.

Users of unpatched or older versions of php will need to adjust their
locales.conf file to match the expected format.

http://www.freetds.org/userguide/locales.htm